### PR TITLE
Properly support PCAP parsing again

### DIFF
--- a/SWProxy.py
+++ b/SWProxy.py
@@ -204,7 +204,7 @@ def parse_pcap(filename):
                        response.status == '200':
                         try:
                             req_plain = decrypt_request(request.body)
-                            resp_plain = decrypt_response(response.body)
+                            resp_plain = decrypt_response(response.body, 2)
                             req_json = json.loads(req_plain)
                             resp_json = json.loads(resp_plain)
 

--- a/SWProxy.py
+++ b/SWProxy.py
@@ -200,10 +200,10 @@ def parse_pcap(filename):
 
                     if len(request) > 0 and len(response) > 0 and \
                        request.method == 'POST' and \
-                       request.uri == '/api/gateway.php' and \
+                       request.uri == '/api/gateway_c2.php' and \
                        response.status == '200':
                         try:
-                            req_plain = decrypt_request(request.body)
+                            req_plain = decrypt_request(request.body, 2)
                             resp_plain = decrypt_response(response.body, 2)
                             req_json = json.loads(req_plain)
                             resp_json = json.loads(resp_plain)
@@ -225,45 +225,48 @@ def parse_pcap(filename):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='SWParser')
-    parser.add_argument('-d', '--debug', action="store_true", default=False)
-    parser.add_argument('-g', '--no-gui', action="store_true", default=False)
-    parser.add_argument('-p', '--port', type=int, default=8080)
-    options = parser.parse_args()
-
-    # Set up logger
-    level = "DEBUG" if options.debug else "INFO"
-    logging.basicConfig(level=level, filename="proxy.log", format='%(asctime)s: %(name)s - %(levelname)s - %(message)s')
-    logger.setLevel(logging.INFO)
-
-    print get_usage_text()
-
-    # attempt to load gui; fallback if import error
-    if not options.no_gui:
-        try:
-            # Import here to avoid importing QT in CLI mode
-            from SWParser.gui import gui
-            from PyQt4.QtGui import QApplication, QIcon
-            from PyQt4.QtCore import QSize
-        except ImportError:
-            print "Failed to load GUI dependencies. Switching to CLI mode"
-            options.no_gui = True
-
-    if options.no_gui:
-        logger.addHandler(logging.StreamHandler())
-        start_proxy_server(options)
+    if len(sys.argv) >= 2 and sys.argv[1].endswith('.pcap'):
+        parse_pcap(sys.argv[1])
     else:
-        app = QApplication(sys.argv)
-        # set the icon
-        icons_path = os.path.join(os.getcwd(), resource_path("icons/"))
-        app_icon = QIcon()
-        app_icon.addFile(icons_path +'16x16.png', QSize(16,16))
-        app_icon.addFile(icons_path + '24x24.png', QSize(24,24))
-        app_icon.addFile(icons_path + '32x32.png', QSize(32,32))
-        app_icon.addFile(icons_path + '48x48.png', QSize(48,48))
-        app_icon.addFile(icons_path + '256x256.png', QSize(256,256))
-        app.setWindowIcon(app_icon)
-        win = gui.MainWindow(get_external_ip(), options.port)
-        logger.addHandler(gui.GuiLogHandler(win))
-        win.show()
-        sys.exit(app.exec_())
+        parser = argparse.ArgumentParser(description='SWParser')
+        parser.add_argument('-d', '--debug', action="store_true", default=False)
+        parser.add_argument('-g', '--no-gui', action="store_true", default=False)
+        parser.add_argument('-p', '--port', type=int, default=8080)
+        options = parser.parse_args()
+
+        # Set up logger
+        level = "DEBUG" if options.debug else "INFO"
+        logging.basicConfig(level=level, filename="proxy.log", format='%(asctime)s: %(name)s - %(levelname)s - %(message)s')
+        logger.setLevel(logging.INFO)
+
+        print get_usage_text()
+
+        # attempt to load gui; fallback if import error
+        if not options.no_gui:
+            try:
+                # Import here to avoid importing QT in CLI mode
+                from SWParser.gui import gui
+                from PyQt4.QtGui import QApplication, QIcon
+                from PyQt4.QtCore import QSize
+            except ImportError:
+                print "Failed to load GUI dependencies. Switching to CLI mode"
+                options.no_gui = True
+
+        if options.no_gui:
+            logger.addHandler(logging.StreamHandler())
+            start_proxy_server(options)
+        else:
+            app = QApplication(sys.argv)
+            # set the icon
+            icons_path = os.path.join(os.getcwd(), resource_path("icons/"))
+            app_icon = QIcon()
+            app_icon.addFile(icons_path +'16x16.png', QSize(16,16))
+            app_icon.addFile(icons_path + '24x24.png', QSize(24,24))
+            app_icon.addFile(icons_path + '32x32.png', QSize(32,32))
+            app_icon.addFile(icons_path + '48x48.png', QSize(48,48))
+            app_icon.addFile(icons_path + '256x256.png', QSize(256,256))
+            app.setWindowIcon(app_icon)
+            win = gui.MainWindow(get_external_ip(), options.port)
+            logger.addHandler(gui.GuiLogHandler(win))
+            win.show()
+            sys.exit(app.exec_())

--- a/SWProxy.py
+++ b/SWProxy.py
@@ -208,13 +208,11 @@ def parse_pcap(filename):
                             req_json = json.loads(req_plain)
                             resp_json = json.loads(resp_plain)
 
-                            if 'command' not in resp_json:
-                                return
-
-                            try:
-                                SWPlugin.call_plugins('process_request', (req_json, resp_json))
-                            except Exception as e:
-                                logger.exception('Exception while executing plugin : {}'.format(e))
+                            if resp_json.get('command') in ['HubUserLogin', 'VisitFriend']:
+                                try:
+                                    SWPlugin.call_plugins('process_request', (req_json, resp_json))
+                                except Exception as e:
+                                    logger.exception('Exception while executing plugin : {}'.format(e))
                         except:
                             import traceback
                             e = sys.exc_info()[0]

--- a/SWProxy.py
+++ b/SWProxy.py
@@ -223,22 +223,33 @@ def parse_pcap(filename):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) >= 2 and sys.argv[1].endswith('.pcap'):
+    parser = argparse.ArgumentParser(description='SWParser')
+    parser.add_argument('-d', '--debug', action="store_true", default=False)
+    parser.add_argument('-g', '--no-gui', action="store_true", default=False)
+    parser.add_argument('-p', '--port', type=int, default=8080)
+    options, unknown_args = parser.parse_known_args()
+
+    # Set up logger
+    level = "DEBUG" if options.debug else "INFO"
+    logging.basicConfig(level=level, filename="proxy.log", format='%(asctime)s: %(name)s - %(levelname)s - %(message)s')
+    logger.setLevel(logging.INFO)
+
+    print get_usage_text()
+
+    # Check if a PCAP file was passed in
+    pcap_filename = None
+    for arg in unknown_args:
+        if arg.endswith('.pcap'):
+            pcap_filename = arg
+            break
+
+    if pcap_filename:
+        # Parse a PCAP file
+        print "Parsing PCAP file..."
         parse_pcap(sys.argv[1])
+        raw_input("Press Enter to exit...")
     else:
-        parser = argparse.ArgumentParser(description='SWParser')
-        parser.add_argument('-d', '--debug', action="store_true", default=False)
-        parser.add_argument('-g', '--no-gui', action="store_true", default=False)
-        parser.add_argument('-p', '--port', type=int, default=8080)
-        options = parser.parse_args()
-
-        # Set up logger
-        level = "DEBUG" if options.debug else "INFO"
-        logging.basicConfig(level=level, filename="proxy.log", format='%(asctime)s: %(name)s - %(levelname)s - %(message)s')
-        logger.setLevel(logging.INFO)
-
-        print get_usage_text()
-
+        # Run the proxy
         # attempt to load gui; fallback if import error
         if not options.no_gui:
             try:


### PR DESCRIPTION
I revived the code in parse_pcap(). When launching SWProxy.py (or .exe) it examines the first argument before passing it on to argparse. If it ends in '.pcap', it calls parse_pcap() which will process it through all the plugins and then exit. 

I restricted parse_pcap() to only call plugins on `HubUserLogin` or `VisitFriend` commands. The only use-case I've seen for parsing pcap files is to get the profile data. Passing every single command to plugins could cause issues with plugins designed to log data or send it to a remote server. 

The steps followed by the users to parse a pcap file should be very simple. They can just drag the .pcap file onto SWProxy.exe and it will run the parse and then exit. I was unable to test this because I couldn't get PyQT4 or SIP installed on my machine, so py2exe failed to build, but this is how arguments work in Windows when you drag files on top of executables so I don't expect any issue. 